### PR TITLE
Allow numeric product searches with letter prefixes; add error formatting, logging and /excel/products timing

### DIFF
--- a/app/controllers/excel.js
+++ b/app/controllers/excel.js
@@ -193,8 +193,11 @@ const buildCodigoFilter = (termRaw) => {
   } else {
     // Solo números: usar búsqueda por prefijo para mejor rendimiento con índices
     const escapedNumbers = escapeRegex(numbersOnly);
-    console.log(`🔍 Búsqueda numérica simple: "${q}" -> regex: "^${escapedNumbers}"`);
-    return { Código: { $regex: `^${escapedNumbers}`, $options: "i" } };
+    const prefixPattern = `^[^0-9]*${escapedNumbers}`;
+    console.log(
+      `🔍 Búsqueda numérica simple: "${q}" -> regex: "${prefixPattern}"`
+    );
+    return { Código: { $regex: prefixPattern, $options: "i" } };
   }
 };
 

--- a/app/routes/excel.js
+++ b/app/routes/excel.js
@@ -15,6 +15,22 @@ const router = express.Router();
 router.get("/productsComplete", isAuthenticated ,getCompleteExcelProductos);
 router.get("/fecha", isAuthenticated ,fechaget);
 router.post("/products", isAuthenticated, async (req, res) => {
+  const requestStart = process.hrtime.bigint();
+  res.once("finish", () => {
+    const elapsedMs = Number(process.hrtime.bigint() - requestStart) / 1e6;
+    const contentLength = res.getHeader("Content-Length");
+    console.log(
+      `✅ /excel/products finish ${res.statusCode} ${elapsedMs.toFixed(0)}ms` +
+        (contentLength ? ` (${contentLength} bytes)` : "")
+    );
+  });
+  res.once("close", () => {
+    const elapsedMs = Number(process.hrtime.bigint() - requestStart) / 1e6;
+    if (!res.writableEnded) {
+      console.warn(`⚠️ /excel/products closed early after ${elapsedMs.toFixed(0)}ms`);
+    }
+  });
+
   console.time("⏱️ /products TOTAL");
 
   try {


### PR DESCRIPTION
### Motivation
- Make product code searches that are numeric-more-flexible so queries like `04313` also match codes with letter prefixes (e.g. `G04313-...`, `A04313-...`) while preserving existing search behavior for hybrid inputs. 
- Improve observability and reliability of the import/update flow by formatting and persisting actionable error messages and by instrumenting request lifecycle timing.

### Description
- Update `app/controllers/excel.js` to expand numeric-only searches to a prefix-aware regex `^[^0-9]*<digits>` and retain the hybrid flexible pattern used when the query contains non-numeric characters. 
- Add a `formatError` helper to `app/controllers/products.js` and wrap `Producto.deleteMany` and `Producto.insertMany` with `await` + `try/catch`, logging and persisting formatted error messages via `global.shared.logError` and returning `500` on Mongo failures. 
- Improve SQS and WooCommerce error handling in `app/controllers/products.js` by using `formatError` when logging SQS send failures and catching failures for the initial `products/batch` call and retry attempts, persisting those errors to the shared logger. 
- Instrument `POST /excel/products` in `app/routes/excel.js` to record total elapsed time and detect early connection closes using `res.once('finish')` and `res.once('close')` with `process.hrtime.bigint()` for accurate ms measurements.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6fa97f8c8329a90fd0adcb080420)