### PR TITLE
Fix client search filtering in /excel/clients

### DIFF
--- a/app/controllers/excel.js
+++ b/app/controllers/excel.js
@@ -89,7 +89,10 @@ let fechas = await Fecha.find({})
 };4
 
 const getExcelClientes = async (condition, page) => {
-  let codigo = condition ? { Nombre: new RegExp(condition.Nombre, "i") } : {};
+  const term = typeof condition === "object" ? condition?.Nombre : condition;
+  const codigo = term
+    ? { Nombre: new RegExp(escapeRegex(term), "i") }
+    : {};
 
   const start = Date.now();
 
@@ -103,7 +106,7 @@ const getExcelClientes = async (condition, page) => {
   console.timeEnd("mongo:find(ExcelClientes)");
 
   console.time("mongo:count(ExcelClientes)");
-  const total = await ExcelClientes.countDocuments(condition);
+  const total = await ExcelClientes.countDocuments(codigo);
   console.timeEnd("mongo:count(ExcelClientes)");
 
   const end = Date.now();


### PR DESCRIPTION
### Motivation
- Normalize and escape the incoming search term so the `/excel/clients` endpoint filters by the requested `Nombre` instead of returning unfiltered rows, and make the count use the same filter.

### Description
- Update `getExcelClientes` to accept a raw name string or an object by extracting `term` and building a safe regex with `escapeRegex(term)` for the `Nombre` field.
- Reuse the same `codigo` filter for both the `find` and `countDocuments` calls so totals reflect the filtered result.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b9e83209083299b29eed904546612)